### PR TITLE
fix subscription

### DIFF
--- a/src/components/TodoApp.js
+++ b/src/components/TodoApp.js
@@ -121,7 +121,7 @@ const toggleTodoMutation = gql`
 
 const allTodoesQuery = gql`
   query allTodoes {
-    allTodoes {
+    allTodoes(orderBy: createdAt_ASC) {
       id
       complete
       text

--- a/src/components/TodoApp.js
+++ b/src/components/TodoApp.js
@@ -51,11 +51,11 @@ class TodoApp extends Component {
           const newTodo = subscriptionData.data.createTodo;
 
           return {
-            allPosts: [
+            allTodoes: [
+              ...previousState.allTodoes,
               {
                 ...newTodo
-              },
-              ...previousState.allTodoes
+              }
             ]
           }
         },

--- a/src/components/TodoList.js
+++ b/src/components/TodoList.js
@@ -26,7 +26,6 @@ export default class TodoList extends React.Component {
     }
     return this.props.todos
       .filter(this._filterTodos)
-      .reverse()
       .map((todo) =>
         <Todo
           key={todo.id}


### PR DESCRIPTION
Explanation: 
- When using `updateQuery` (for subscriptions) or `updateQueries` (for mutations), you have to return an object whose keys will be matched with all currently known query names. That's why we have to say `allTodoes`
- I changed the displaying order and removed the `reverse()` statement. I think this order is more natural (latest todo at the bottom of the list).

Current limitations:

- no subscription on update/delete. We'll change the Graphcool subscription API so you can subscribe to multiple mutations at the same time, so this we'll be pretty easy to handle. Stay tuned!
- after deleting a Todo, sometimes the UI doesn't update correctly. The correct way would be to [use `updateQueries` instead of `refetch()`](https://github.com/graphcool-examples/react-apollo-todo-example/issues/6), however that is [undergoing significant changes](https://github.com/apollographql/apollo-client/issues/1224) at the moment.
- just as a heads up, the component setup in the example you referred to  [can be significantly improved](https://github.com/graphcool-examples/react-apollo-todo-example/issues/5). This is my bad :stuck_out_tongue: 

Not sure if you consider #1 to be fixed by this.

All in all, I'd say these are not huge issues and can be fixed once the above two changes are live.
Thanks for putting this together so quickly! :muscle: 